### PR TITLE
[JITERA] Create Migration for 400+ Dummy Tables

### DIFF
--- a/src/migrations/1742282970589-CreateDummyTables.ts
+++ b/src/migrations/1742282970589-CreateDummyTables.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateDummyTables1742282970589 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (let i = 1; i <= 400; i++) {
+            await queryRunner.createTable(new Table({
+                name: `dummy_table_${i}`,
+                columns: [
+                    {
+                        name: 'id',
+                        type: 'int',
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: 'increment',
+                    },
+                    {
+                        name: 'name',
+                        type: 'varchar',
+                        length: '255',
+                    },
+                    {
+                        name: 'description',
+                        type: 'text',
+                    },
+                    {
+                        name: 'created_at',
+                        type: 'timestamp',
+                        default: 'CURRENT_TIMESTAMP',
+                    },
+                    {
+                        name: 'updated_at',
+                        type: 'timestamp',
+                        default: 'CURRENT_TIMESTAMP',
+                    },
+                ],
+            }), true);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        for (let i = 1; i <= 400; i++) {
+            await queryRunner.dropTable(`dummy_table_${i}`);
+        }
+    }
+}


### PR DESCRIPTION
## Overview
This pull request introduces a new migration file that generates 400 dummy tables in the backend. Each table is designed to have multiple columns, which can be useful for testing and development purposes.

## Changes
- **Migration File**: Added a new migration file located at `/src/migrations/1742282970589-CreateDummyTables.ts`.
  - This file contains the logic to create 400 tables, each with a predefined structure.
  - The tables are named systematically to ensure easy identification and access.
  - Each table includes multiple columns to simulate a realistic database schema.

## Purpose
The primary goal of this migration is to facilitate testing and development by providing a large set of dummy data structures. This will help in performance testing, UI development, and other scenarios where a substantial amount of data is required without the need for real data.

Please review the migration code and let me know if there are any changes or improvements needed.
